### PR TITLE
Make translations literal and add optional breakdown

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,8 +4,22 @@ const statusEl = document.getElementById('status');
 const transcriptEl = document.getElementById('transcript');
 const remoteAudioEl = document.getElementById('remoteAudio');
 const langSel = document.getElementById('lang');
+const verboseEl = document.getElementById('verbose');
+const breakdownSection = document.getElementById('breakdownSection');
+const breakdownEl = document.getElementById('breakdown');
 
-let pc, localStream, dataChannel;
+let pc, localStream, dataChannel, verboseEnabled = false;
+
+if (verboseEl && breakdownSection && breakdownEl) {
+  verboseEl.addEventListener('change', () => {
+    if (verboseEl.checked) {
+      breakdownSection?.classList.remove('hidden');
+    } else {
+      breakdownEl.textContent = '';
+      breakdownSection?.classList.add('hidden');
+    }
+  });
+}
 
 const TOKEN_ENDPOINT = (() => {
   if (typeof window !== 'undefined' && window.RT_TOKEN_ENDPOINT) {
@@ -17,11 +31,11 @@ const TOKEN_ENDPOINT = (() => {
   return '/api/rt-token';
 })();
 
-async function getEphemeralToken(selectedLanguage) {
+async function getEphemeralToken(selectedLanguage, verbose) {
   const resp = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({ language: selectedLanguage })
+    body: JSON.stringify({ language: selectedLanguage, verbose })
   });
   if (!resp.ok) {
     const errorBody = await resp.text();
@@ -40,8 +54,16 @@ async function connect() {
       audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true }
     });
 
+    verboseEnabled = !!verboseEl?.checked;
+    if (breakdownEl) breakdownEl.textContent = '';
+    if (verboseEnabled) {
+      breakdownSection?.classList.remove('hidden');
+    } else {
+      breakdownSection?.classList.add('hidden');
+    }
+
     statusEl.textContent = 'minting token…';
-    const token = await getEphemeralToken(langSel.value);
+    const token = await getEphemeralToken(langSel.value, verboseEnabled);
 
     statusEl.textContent = 'creating peer connection…';
     pc = new RTCPeerConnection();
@@ -56,6 +78,8 @@ async function connect() {
         const msg = JSON.parse(ev.data);
         if (msg.type === 'transcript.partial' || msg.type === 'transcript.final') {
           transcriptEl.textContent = msg.text;
+        } else if (msg.type === 'translation.breakdown') {
+          renderBreakdown(msg);
         }
       } catch { /* ignore non-JSON messages */ }
     };
@@ -91,6 +115,9 @@ async function connect() {
     console.error(err);
     statusEl.textContent = 'error (see console)';
     connectBtn.disabled = false;
+    if (breakdownEl) breakdownEl.textContent = '';
+    breakdownSection?.classList.add('hidden');
+    verboseEnabled = false;
   }
 }
 
@@ -99,6 +126,9 @@ function stop() {
   connectBtn.disabled = false;
   statusEl.textContent = 'stopped';
   transcriptEl.textContent = '';
+  if (breakdownEl) breakdownEl.textContent = '';
+  breakdownSection?.classList.add('hidden');
+  verboseEnabled = false;
   if (dataChannel && dataChannel.readyState === 'open') dataChannel.close();
   if (pc) pc.close();
   if (localStream) localStream.getTracks().forEach(t => t.stop());
@@ -106,3 +136,72 @@ function stop() {
 
 connectBtn.onclick = connect;
 stopBtn.onclick = stop;
+
+function renderBreakdown(msg) {
+  if (!verboseEnabled || !breakdownEl) return;
+  if (breakdownSection) breakdownSection.classList.remove('hidden');
+  breakdownEl.innerHTML = '';
+
+  const safeString = (value) => (typeof value === 'string' ? value.trim() : '');
+  const sourceSentence = safeString(msg.source || msg.original || msg.input);
+  const targetSentence = safeString(msg.target || msg.translation || msg.text);
+
+  if (sourceSentence) {
+    const originalRow = document.createElement('div');
+    originalRow.className = 'breakdown-row';
+    originalRow.textContent = `Original: ${sourceSentence}`;
+    breakdownEl.appendChild(originalRow);
+  }
+
+  if (targetSentence) {
+    const translatedRow = document.createElement('div');
+    translatedRow.className = 'breakdown-row';
+    translatedRow.textContent = `Translation: ${targetSentence}`;
+    breakdownEl.appendChild(translatedRow);
+  }
+
+  const breakdownList = Array.isArray(msg.breakdown) ? msg.breakdown : null;
+
+  if (breakdownList && breakdownList.length) {
+    breakdownList.forEach((entry) => {
+      const sourceWord = safeString(entry.source || entry.input || entry.word);
+      const targetWord = safeString(entry.target || entry.translation || entry.output);
+      const meaning = safeString(entry.meaning || entry.gloss || entry.note);
+
+      if (!sourceWord && !targetWord && !meaning) return;
+
+      const row = document.createElement('div');
+      row.className = 'breakdown-row';
+
+      if (sourceWord) {
+        const sourceEl = document.createElement('strong');
+        sourceEl.textContent = sourceWord;
+        row.appendChild(sourceEl);
+      }
+
+      if (targetWord) {
+        if (row.childNodes.length) {
+          const arrowEl = document.createElement('span');
+          arrowEl.textContent = ' → ';
+          row.appendChild(arrowEl);
+        }
+        const targetEl = document.createElement('strong');
+        targetEl.textContent = targetWord;
+        row.appendChild(targetEl);
+      }
+
+      if (meaning) {
+        const meaningEl = document.createElement('span');
+        meaningEl.textContent = (row.childNodes.length ? ' — ' : '') + meaning;
+        row.appendChild(meaningEl);
+      }
+
+      breakdownEl.appendChild(row);
+    });
+  } else if (msg.explanation || msg.details) {
+    const fallbackRow = document.createElement('div');
+    fallbackRow.className = 'breakdown-row';
+    fallbackRow.textContent = safeString(msg.explanation || msg.details);
+    breakdownEl.appendChild(fallbackRow);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -7,13 +7,19 @@
   <style>
     body{font-family:system-ui,Segoe UI,Arial;margin:2rem;max-width:800px}
     button,select{padding:.6rem 1rem;margin:.25rem;border-radius:.6rem;border:1px solid #ccc;cursor:pointer}
+    label.toggle{display:inline-flex;align-items:center;gap:.5rem;margin:.5rem 0;cursor:pointer}
+    label.toggle input{cursor:pointer}
     #status{margin:.5rem 0;color:#555}
     #transcript{white-space:pre-wrap;background:#f7f7f7;border:1px solid #eee;padding:1rem;border-radius:.6rem;min-height:6rem}
+    #breakdown{white-space:pre-wrap;background:#f7f7f7;border:1px solid #eee;padding:1rem;border-radius:.6rem;margin-top:.5rem}
+    .hidden{display:none}
+    .breakdown-row{margin:.35rem 0}
+    .breakdown-row strong{font-weight:600}
   </style>
 </head>
 <body>
   <h1>🎙️ Voice Translator</h1>
-  <p>Speak into the mic; the AI replies <b>out loud</b> in your chosen language.</p>
+  <p>Speak into the mic; the AI repeats a literal translation <b>out loud</b> in your chosen language.</p>
 
   <label for="lang">Reply language: </label>
   <select id="lang">
@@ -25,6 +31,8 @@
     <option>Chinese</option>
   </select>
 
+  <label class="toggle"><input type="checkbox" id="verbose" /> Verbose word-by-word breakdown</label>
+
   <div>
     <button id="connect">Connect mic</button>
     <button id="stop" disabled>Stop</button>
@@ -33,6 +41,11 @@
 
   <h3>Transcript</h3>
   <div id="transcript"></div>
+
+  <section id="breakdownSection" class="hidden">
+    <h3>Word-by-word breakdown</h3>
+    <div id="breakdown"></div>
+  </section>
 
   <audio id="remoteAudio" autoplay></audio>
 


### PR DESCRIPTION
## Summary
- tighten the realtime session instructions so the assistant only delivers literal spoken translations
- add a UI toggle to request a word-by-word breakdown and surface the details when provided
- forward the verbose flag through the token request and render structured breakdown messages in the client

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8f882f3788333af8114868077d4bf