### PR TITLE
Add separate input and output transcript views

### DIFF
--- a/api/rt-token.js
+++ b/api/rt-token.js
@@ -11,10 +11,18 @@ export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).send('Method not allowed');
 
   try {
-    const { language = 'Spanish' } = req.body || {};
-    const instructions =
+    const { language = 'Spanish', verbose = false } = req.body || {};
+    const verboseMode = typeof verbose === 'string'
+      ? verbose.toLowerCase() === 'true'
+      : Boolean(verbose);
+
+    const baseInstructions =
       `You are a translator bot. The user may speak any language. ` +
-      `Translate and reply ONLY in spoken ${language}. Keep replies concise.`;
+      `Translate and reply ONLY in spoken ${language}.`;
+
+    const instructions = verboseMode
+      ? baseInstructions + ' Provide a detailed, word-by-word explanation of the translation so the listener understands how each segment maps to the final spoken response.'
+      : baseInstructions + ' Keep replies concise and natural sounding.';
 
     const r = await fetch('https://api.openai.com/v1/realtime/sessions', {
       method: 'POST',

--- a/app.js
+++ b/app.js
@@ -1,11 +1,220 @@
 const connectBtn = document.getElementById('connect');
 const stopBtn = document.getElementById('stop');
 const statusEl = document.getElementById('status');
-const transcriptEl = document.getElementById('transcript');
+const transcriptInputEl = document.getElementById('transcript-input');
+const transcriptOutputEl = document.getElementById('transcript-output');
+const transcriptInputLabelEl = document.getElementById('transcript-input-label');
+const transcriptOutputLabelEl = document.getElementById('transcript-output-label');
 const remoteAudioEl = document.getElementById('remoteAudio');
 const langSel = document.getElementById('lang');
 
 let pc, localStream, dataChannel;
+let activeResponseId = null;
+let latestUserTranscript = '';
+let latestAssistantTranscript = '';
+let detectedInputLanguage = '';
+
+function updateOutputTranscriptLabel() {
+  if (!transcriptOutputLabelEl || !langSel) return;
+  transcriptOutputLabelEl.textContent = `Output (${langSel.value})`;
+}
+
+function updateInputTranscriptLabel(language) {
+  if (!transcriptInputLabelEl) return;
+  if (!language) {
+    transcriptInputLabelEl.textContent = 'Input (what you said)';
+    return;
+  }
+  const normalized = language.trim();
+  try {
+    const displayNames = new Intl.DisplayNames([navigator.language || 'en'], { type: 'language' });
+    const prettyName = displayNames.of(normalized) || normalized;
+    transcriptInputLabelEl.textContent = `Input (${prettyName})`;
+  } catch {
+    transcriptInputLabelEl.textContent = `Input (${normalized})`;
+  }
+}
+
+function resetTranscripts() {
+  activeResponseId = null;
+  latestUserTranscript = '';
+  latestAssistantTranscript = '';
+  detectedInputLanguage = '';
+  if (transcriptInputEl) transcriptInputEl.textContent = '';
+  if (transcriptOutputEl) transcriptOutputEl.textContent = '';
+  updateInputTranscriptLabel('');
+}
+
+function handleTranscriptEvent(msg) {
+  if (!msg || typeof msg !== 'object') return;
+  const type = msg.type;
+
+  if (type === 'input_audio_buffer.speech_started') {
+    latestUserTranscript = '';
+    if (transcriptInputEl) transcriptInputEl.textContent = '';
+    return;
+  }
+
+  if (type === 'transcript.partial' || type === 'transcript.final') {
+    const text = extractMessageText(msg);
+    if (typeof text === 'string' && text.trim()) {
+      latestUserTranscript = text;
+      if (transcriptInputEl) transcriptInputEl.textContent = latestUserTranscript;
+    }
+    const language = msg.language || msg.lang || msg.transcript?.language;
+    if (typeof language === 'string' && language && language !== detectedInputLanguage) {
+      detectedInputLanguage = language;
+      updateInputTranscriptLabel(language);
+    }
+    return;
+  }
+
+  if (type === 'response.created') {
+    activeResponseId = msg.response?.id || null;
+    latestAssistantTranscript = '';
+    if (transcriptOutputEl) transcriptOutputEl.textContent = '';
+    return;
+  }
+
+  if (type === 'response.output_text.delta') {
+    if (!activeResponseId || msg.response_id === activeResponseId) {
+      const delta = typeof msg.delta === 'string' ? msg.delta : extractMessageText(msg);
+      if (typeof delta === 'string' && delta) {
+        latestAssistantTranscript += delta;
+        if (transcriptOutputEl) transcriptOutputEl.textContent = latestAssistantTranscript;
+      }
+    }
+    return;
+  }
+
+  if (type === 'response.output_text.done') {
+    if (!activeResponseId || msg.response_id === activeResponseId) {
+      const finalText = typeof msg.output_text === 'string'
+        ? msg.output_text
+        : Array.isArray(msg.output_text)
+          ? msg.output_text.join('')
+          : extractMessageText(msg) || latestAssistantTranscript;
+      if (typeof finalText === 'string' && finalText) {
+        latestAssistantTranscript = finalText;
+        if (transcriptOutputEl) transcriptOutputEl.textContent = latestAssistantTranscript;
+      }
+    }
+    return;
+  }
+
+  if (type === 'response.completed') {
+    if (!activeResponseId || msg.response?.id === activeResponseId) {
+      activeResponseId = null;
+    }
+    return;
+  }
+
+  if (typeof type === 'string' && type.includes('transcript')) {
+    const text = extractMessageText(msg);
+    if (typeof text === 'string' && text.trim()) {
+      const treatAsInput = type.includes('input') || type.includes('user');
+      if (treatAsInput) {
+        latestUserTranscript = text;
+        if (transcriptInputEl) transcriptInputEl.textContent = latestUserTranscript;
+        const language = msg.language || msg.lang || msg.transcript?.language;
+        if (typeof language === 'string' && language && language !== detectedInputLanguage) {
+          detectedInputLanguage = language;
+          updateInputTranscriptLabel(language);
+        }
+      } else {
+        latestAssistantTranscript = text;
+        if (transcriptOutputEl) transcriptOutputEl.textContent = latestAssistantTranscript;
+      }
+    }
+    return;
+  }
+
+  const text = extractMessageText(msg);
+  if (!text) return;
+
+  const role = (getMessageRole(msg) || '').toLowerCase();
+  if (role.includes('user') || role.includes('input')) {
+    latestUserTranscript = text;
+    if (transcriptInputEl) transcriptInputEl.textContent = latestUserTranscript;
+  } else if (role.includes('assistant') || role.includes('output') || role.includes('agent')) {
+    latestAssistantTranscript = text;
+    if (transcriptOutputEl) transcriptOutputEl.textContent = latestAssistantTranscript;
+  } else if (!latestUserTranscript) {
+    latestUserTranscript = text;
+    if (transcriptInputEl) transcriptInputEl.textContent = latestUserTranscript;
+  } else {
+    latestAssistantTranscript = text;
+    if (transcriptOutputEl) transcriptOutputEl.textContent = latestAssistantTranscript;
+  }
+}
+
+function extractMessageText(msg) {
+  if (!msg || typeof msg !== 'object') return '';
+  if (typeof msg.text === 'string') return msg.text;
+  if (Array.isArray(msg.text)) return msg.text.join('');
+  if (typeof msg.delta === 'string') return msg.delta;
+  if (Array.isArray(msg.delta)) return msg.delta.join('');
+  if (msg.delta && typeof msg.delta === 'object') {
+    if (typeof msg.delta.text === 'string') return msg.delta.text;
+    if (Array.isArray(msg.delta.text)) return msg.delta.text.join('');
+    if (typeof msg.delta.transcript === 'string') return msg.delta.transcript;
+  }
+  if (typeof msg.transcript === 'string') return msg.transcript;
+  if (typeof msg.message === 'string') return msg.message;
+  if (typeof msg.output_text === 'string') return msg.output_text;
+  if (Array.isArray(msg.output_text)) return msg.output_text.join('');
+  if (msg.transcript && typeof msg.transcript.text === 'string') return msg.transcript.text;
+  if (msg.transcript && typeof msg.transcript.delta === 'string') return msg.transcript.delta;
+  if (msg.response && Array.isArray(msg.response.output)) {
+    const pieces = [];
+    for (const item of msg.response.output) {
+      if (!item || typeof item !== 'object' || !Array.isArray(item.content)) continue;
+      for (const content of item.content) {
+        if (!content || typeof content !== 'object') continue;
+        if (typeof content.text === 'string') pieces.push(content.text);
+        if (typeof content.transcript === 'string') pieces.push(content.transcript);
+        if (typeof content.delta === 'string') pieces.push(content.delta);
+        if (Array.isArray(content.delta)) pieces.push(content.delta.join(''));
+      }
+    }
+    if (pieces.length) return pieces.join('');
+  }
+  return '';
+}
+
+function getMessageRole(msg) {
+  const candidates = [
+    msg.participant,
+    msg.role,
+    msg.speaker,
+    msg.source,
+    msg.from,
+    msg.direction,
+    msg.channel,
+    msg.track,
+    msg.audio_track,
+    msg.audio_track_id,
+    msg.transcript?.participant,
+    msg.transcript?.role,
+    msg.response?.role,
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (typeof candidate === 'string') return candidate;
+    if (typeof candidate === 'object') {
+      for (const key of ['role', 'name', 'id', 'type']) {
+        if (typeof candidate[key] === 'string') return candidate[key];
+      }
+    }
+  }
+  return '';
+}
+
+if (langSel) {
+  updateOutputTranscriptLabel();
+  langSel.addEventListener('change', updateOutputTranscriptLabel);
+}
 
 const TOKEN_ENDPOINT = (() => {
   if (typeof window !== 'undefined' && window.RT_TOKEN_ENDPOINT) {
@@ -34,6 +243,8 @@ async function getEphemeralToken(selectedLanguage) {
 
 async function connect() {
   try {
+    resetTranscripts();
+    if (langSel) updateOutputTranscriptLabel();
     connectBtn.disabled = true;
     statusEl.textContent = 'requesting mic…';
     localStream = await navigator.mediaDevices.getUserMedia({
@@ -41,7 +252,8 @@ async function connect() {
     });
 
     statusEl.textContent = 'minting token…';
-    const token = await getEphemeralToken(langSel.value);
+    const selectedLanguage = langSel ? langSel.value : 'Spanish';
+    const token = await getEphemeralToken(selectedLanguage);
 
     statusEl.textContent = 'creating peer connection…';
     pc = new RTCPeerConnection();
@@ -54,10 +266,10 @@ async function connect() {
     dataChannel.onmessage = (ev) => {
       try {
         const msg = JSON.parse(ev.data);
-        if (msg.type === 'transcript.partial' || msg.type === 'transcript.final') {
-          transcriptEl.textContent = msg.text;
-        }
-      } catch { /* ignore non-JSON messages */ }
+        handleTranscriptEvent(msg);
+      } catch (err) {
+        console.warn('Non-JSON event from data channel', err, ev.data);
+      }
     };
 
     // send mic to the model
@@ -91,6 +303,8 @@ async function connect() {
     console.error(err);
     statusEl.textContent = 'error (see console)';
     connectBtn.disabled = false;
+    stopBtn.disabled = true;
+    resetTranscripts();
   }
 }
 
@@ -98,7 +312,7 @@ function stop() {
   stopBtn.disabled = true;
   connectBtn.disabled = false;
   statusEl.textContent = 'stopped';
-  transcriptEl.textContent = '';
+  resetTranscripts();
   if (dataChannel && dataChannel.readyState === 'open') dataChannel.close();
   if (pc) pc.close();
   if (localStream) localStream.getTracks().forEach(t => t.stop());

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const transcriptInputLabelEl = document.getElementById('transcript-input-label')
 const transcriptOutputLabelEl = document.getElementById('transcript-output-label');
 const remoteAudioEl = document.getElementById('remoteAudio');
 const langSel = document.getElementById('lang');
+const verboseToggle = document.getElementById('verbose');
 
 let pc, localStream, dataChannel;
 let activeResponseId = null;
@@ -226,11 +227,14 @@ const TOKEN_ENDPOINT = (() => {
   return '/api/rt-token';
 })();
 
-async function getEphemeralToken(selectedLanguage) {
+async function getEphemeralToken(selectedLanguage, verboseMode) {
   const resp = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({ language: selectedLanguage })
+    body: JSON.stringify({
+      language: selectedLanguage,
+      verbose: Boolean(verboseMode)
+    })
   });
   if (!resp.ok) {
     const errorBody = await resp.text();
@@ -253,7 +257,8 @@ async function connect() {
 
     statusEl.textContent = 'minting token…';
     const selectedLanguage = langSel ? langSel.value : 'Spanish';
-    const token = await getEphemeralToken(selectedLanguage);
+    const verboseMode = verboseToggle ? verboseToggle.checked : false;
+    const token = await getEphemeralToken(selectedLanguage, verboseMode);
 
     statusEl.textContent = 'creating peer connection…';
     pc = new RTCPeerConnection();

--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
     body{font-family:system-ui,Segoe UI,Arial;margin:2rem;max-width:800px}
     button,select{padding:.6rem 1rem;margin:.25rem;border-radius:.6rem;border:1px solid #ccc;cursor:pointer}
     #status{margin:.5rem 0;color:#555}
-    #transcript{white-space:pre-wrap;background:#f7f7f7;border:1px solid #eee;padding:1rem;border-radius:.6rem;min-height:6rem}
+    .transcript-wrapper{margin-top:1.5rem}
+    .transcript-grid{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}
+    .transcript-box{white-space:pre-wrap;background:#f7f7f7;border:1px solid #eee;padding:1rem;border-radius:.6rem;min-height:6rem}
+    .transcript-heading{margin:.25rem 0 .75rem;font-size:1rem;color:#333}
   </style>
 </head>
 <body>
@@ -31,8 +34,19 @@
     <span id="status">idle</span>
   </div>
 
-  <h3>Transcript</h3>
-  <div id="transcript"></div>
+  <section class="transcript-wrapper">
+    <h3>Transcript</h3>
+    <div class="transcript-grid">
+      <div>
+        <h4 class="transcript-heading" id="transcript-input-label">Input (what you said)</h4>
+        <div id="transcript-input" class="transcript-box" aria-live="polite"></div>
+      </div>
+      <div>
+        <h4 class="transcript-heading" id="transcript-output-label">Output</h4>
+        <div id="transcript-output" class="transcript-box" aria-live="polite"></div>
+      </div>
+    </div>
+  </section>
 
   <audio id="remoteAudio" autoplay></audio>
 

--- a/index.html
+++ b/index.html
@@ -34,6 +34,11 @@
     <span id="status">idle</span>
   </div>
 
+  <label for="verbose" style="display:inline-flex;align-items:center;gap:.5rem;margin-top:.75rem;">
+    <input type="checkbox" id="verbose" />
+    Verbose mode (word-by-word translation)
+  </label>
+
   <section class="transcript-wrapper">
     <h3>Transcript</h3>
     <div class="transcript-grid">


### PR DESCRIPTION
## Summary
- add dedicated transcript boxes for the spoken input and translated output with updated layout styles
- enhance realtime event handling to populate each transcript pane and track detected input language
- refresh transcript labels based on detected input language and the currently selected output language

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8f79bf0148333a1afbd5bf987fdd2